### PR TITLE
Fix OSX tty folder mistake

### DIFF
--- a/rs232-linux.c
+++ b/rs232-linux.c
@@ -6,7 +6,7 @@
 
     The MIT License (MIT)
 
-    Copyright (c) 2013-2015 Frédéric Meslin, Florent Touchard
+    Copyright (c) 2013-2015 FrÃ©dÃ©ric Meslin, Florent Touchard
     Email: fredericmeslin@hotmail.com
     Website: www.fredslab.net
     Twitter: @marzacdev
@@ -53,7 +53,7 @@
 /** Base name for COM devices */
 #if defined(__APPLE__) && defined(__MACH__)
     static const char * devBases[] = {
-        "/dev/tty."
+        "tty."
     };
     static int noBases = 1;
 #else


### PR DESCRIPTION
No need to have "/dev/" since the query is already in the "dev" folder
